### PR TITLE
Protect against response body not being able to be parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,14 @@ class Fasquest
         else {
           if (res.headers['content-type'] && res.headers['content-type'].indexOf('json') > -1)
           {
-            res.body = JSON.parse(res.body);
+            try
+            {
+              res.body = JSON.parse(res.body);
+            }
+            catch (e)
+            {
+              // do nothing 
+            }
           }
           if (options.simple)
           {


### PR DESCRIPTION
Sometimes, a response is sent with a json Content-Type header but might actually be an empty response. If this is the case, this fails resulting in the entire request from failing.